### PR TITLE
Add edge masks

### DIFF
--- a/acdc/TLACDCEdge.py
+++ b/acdc/TLACDCEdge.py
@@ -44,8 +44,16 @@ class Edge:
         edge_type: EdgeType,
         present: bool = True,
         effect_size: Optional[float] = None,
-        mask: Union[float, Float[torch.Tensor, '']] = 1.0,
+        mask: Union[float, Float[torch.Tensor, '']] = 0.0,
     ):
+        """Mask is used to interpolate between the original value and the corrupted value.
+        
+        If it's 1.0, we just use the corrupted value!
+        
+        We should always have edge.present=True when using mask
+        
+        TODO: implement direct computation version"""
+
         self.edge_type = edge_type
         self.present = present
         self.effect_size = effect_size

--- a/acdc/TLACDCEdge.py
+++ b/acdc/TLACDCEdge.py
@@ -1,7 +1,9 @@
 import sys
 from collections import defaultdict
 from enum import Enum
-from typing import Optional, List
+from typing import Optional, List, Union, Tuple, Dict, Any
+from jaxtyping import Float
+import torch
 
 
 class EdgeType(Enum):
@@ -42,10 +44,12 @@ class Edge:
         edge_type: EdgeType,
         present: bool = True,
         effect_size: Optional[float] = None,
+        mask: Union[float, Float[torch.Tensor, '']] = 1.0,
     ):
         self.edge_type = edge_type
         self.present = present
         self.effect_size = effect_size
+        self.mask = mask
 
     def __repr__(self) -> str:
         return f"Edge({self.edge_type}, {self.present})"

--- a/acdc/TLACDCEdge.py
+++ b/acdc/TLACDCEdge.py
@@ -46,13 +46,10 @@ class Edge:
         effect_size: Optional[float] = None,
         mask: Union[float, Float[torch.Tensor, '']] = 0.0,
     ):
-        """Mask is used to interpolate between the original value and the corrupted value.
-        
+        """`mask` is used to interpolate between the original value and the corrupted value.        
         If it's 1.0, we just use the corrupted value!
-        
-        We should always have edge.present=True when using mask
-        
-        TODO: implement direct computation version"""
+
+        N.B: always have edge.present=True when using mask"""        
 
         self.edge_type = edge_type
         self.present = present

--- a/acdc/TLACDCExperiment.py
+++ b/acdc/TLACDCExperiment.py
@@ -309,7 +309,7 @@ class TLACDCExperiment:
                     if verbose:
                         print(f"Overwrote {receiver_index} with norm {old_z[receiver_index.as_index].norm().item()}")
 
-                    hook_point_input[receiver_index.as_index] += (-edge.mask + 1.0) * (old_z[receiver_index.as_index].to(hook_point_input.device) - self.global_cache.corrupted_cache[sender_node][sender_index.as_index].to(hook_point_input.device))
+                    hook_point_input[receiver_index.as_index] += (-edge.mask + 1.0) * (old_z[receiver_index.as_index].to(hook_point_input.device) - self.global_cache.corrupted_cache[hook.name][receiver_index.as_index].to(hook_point_input.device))
     
             return hook_point_input
 

--- a/acdc/TLACDCExperiment.py
+++ b/acdc/TLACDCExperiment.py
@@ -309,7 +309,7 @@ class TLACDCExperiment:
                     if verbose:
                         print(f"Overwrote {receiver_index} with norm {old_z[receiver_index.as_index].norm().item()}")
 
-                    hook_point_input[receiver_index.as_index] = old_z[receiver_index.as_index].to(hook_point_input.device)
+                    hook_point_input[receiver_index.as_index] += (-edge.mask + 1.0) * (old_z[receiver_index.as_index].to(hook_point_input.device) - self.global_cache.corrupted_cache[sender_node][sender_index.as_index].to(hook_point_input.device))
     
             return hook_point_input
 
@@ -349,7 +349,7 @@ class TLACDCExperiment:
                     
                     if edge.edge_type == EdgeType.ADDITION:
                         # Add the effect of the new head (from the current forward pass)
-                        hook_point_input[receiver_node_index.as_index] += edge.mask * self.global_cache.online_cache[
+                        hook_point_input[receiver_node_index.as_index] += (-edge.mask + 1.0) * self.global_cache.online_cache[
                             sender_node_name
                         ][sender_node_index.as_index].to(hook_point_input.device)
                         # Remove the effect of this head (from the corrupted data)

--- a/acdc/TLACDCExperiment.py
+++ b/acdc/TLACDCExperiment.py
@@ -349,11 +349,11 @@ class TLACDCExperiment:
                     
                     if edge.edge_type == EdgeType.ADDITION:
                         # Add the effect of the new head (from the current forward pass)
-                        hook_point_input[receiver_node_index.as_index] += self.global_cache.online_cache[
+                        hook_point_input[receiver_node_index.as_index] += edge.mask * self.global_cache.online_cache[
                             sender_node_name
                         ][sender_node_index.as_index].to(hook_point_input.device)
                         # Remove the effect of this head (from the corrupted data)
-                        hook_point_input[receiver_node_index.as_index] -= self.global_cache.corrupted_cache[
+                        hook_point_input[receiver_node_index.as_index] -= (-edge.mask + 1.0) * self.global_cache.corrupted_cache[
                             sender_node_name
                         ][sender_node_index.as_index].to(hook_point_input.device)
 


### PR DESCRIPTION
Allows interpolation between clean and corrupted. Off by default (`edge.mask=0.0`)